### PR TITLE
stabilize ASG capacity for redundant tasks

### DIFF
--- a/.ai/reviews/2026-07-22-asg-stabilization.md
+++ b/.ai/reviews/2026-07-22-asg-stabilization.md
@@ -2,30 +2,38 @@
 
 ## 結果
 
-マージを妨げる指摘はありません。ECS の `desiredCount: 2` と
-`distinctInstance` に対し、ASG の `maxCapacity: 4`、Spot インスタンスの
-多様化、Launch Template 移行時の rolling update が整合しています。
+Cloud確認で検出した、ASG rolling update中に1台まで減らせる問題と、ECS
+deployment中に1タスクまで減らせる問題は修正済みです。マージを妨げる指摘は
+ありません。修正後のChange Set確認はデプロイゲートとして残っています。
 
 ## 検証
 
-- `mise exec -- npm test -- --runInBand`: 成功（6 tests）
+- `mise exec -- npm test -- --runInBand`: 成功（7 tests）
 - `mise exec -- npx tsc --noEmit`: 成功
 - `mise exec -- npm run build`: 成功
 - `mise exec -- npm run synth -- MiwkeyPublicStack --quiet --output <fresh-dir>`: 成功
 - synth 結果:
   - ASG `MaxSize: 4`
   - Spot allocation strategy `capacity-optimized`
-  - rolling update `MaxBatchSize: 1` / `MinInstancesInService: 1` / `PauseTime: PT5M`
+  - rolling update `MaxBatchSize: 1` / `MinInstancesInService: 2` / `PauseTime: PT5M`
+  - ECS deployment `MinimumHealthyPercent: 100` / `MaximumPercent: 200`
   - ECS placement `distinctInstance` / `binpack: MEMORY`
 - `git diff --check develop...feature/asg-stabilization`: 成功
 
+## Cloud確認
+
+- パラメータを指定した既存Change SetではRDS Secret差分が消えています。
+- 実ASGは `DesiredCapacity: 2` / `MaxSize: 2` で、Healthyな2台が稼働しています。
+- 実ECS serviceは `desiredCount: 2` / `runningCount: 2` / `pendingCount: 0` です。
+- Launch Template移行時にARM64 ECS Optimized AL2 AMIが`20251031`版から
+  `20260714`版へ更新されます。新AMIはavailableです。
+
 ## 残存リスク
 
-- `agent-readonly` profile は CDK lookup role を assume できないため、実環境の
-  `cdk diff` は未実施です。デプロイ前に lookup 可能な承認済み profile で
-  cloud diff を確認する必要があります。
+- 既存の `asg-stabilization-review` Change Setは今回の2修正より前に作成されて
+  います。削除して再作成し、Secret差分がなく、ASGが最低2台、ECSが最低100%
+  healthyになることをデプロイ前に確認します。
 - rolling update の pause はアプリケーションの正常性を保証しないため、初回
   デプロイ中は ECS running task、新規 container instance、ALB health を監視します。
-- 既存の deprecated `containerInsights`、ECS IMDS、既定
-  `minHealthyPercent` の warning は今回のスコープ外です。
+- 既存の deprecated `containerInsights` とECS IMDSのwarningは今回のスコープ外です。
 - `npm ci` が報告する依存関係 vulnerability は今回のスコープ外です。

--- a/.ai/reviews/2026-07-22-asg-stabilization.md
+++ b/.ai/reviews/2026-07-22-asg-stabilization.md
@@ -1,0 +1,31 @@
+# ASG Stabilization Review
+
+## 結果
+
+マージを妨げる指摘はありません。ECS の `desiredCount: 2` と
+`distinctInstance` に対し、ASG の `maxCapacity: 4`、Spot インスタンスの
+多様化、Launch Template 移行時の rolling update が整合しています。
+
+## 検証
+
+- `mise exec -- npm test -- --runInBand`: 成功（6 tests）
+- `mise exec -- npx tsc --noEmit`: 成功
+- `mise exec -- npm run build`: 成功
+- `mise exec -- npm run synth -- MiwkeyPublicStack --quiet --output <fresh-dir>`: 成功
+- synth 結果:
+  - ASG `MaxSize: 4`
+  - Spot allocation strategy `capacity-optimized`
+  - rolling update `MaxBatchSize: 1` / `MinInstancesInService: 1` / `PauseTime: PT5M`
+  - ECS placement `distinctInstance` / `binpack: MEMORY`
+- `git diff --check develop...feature/asg-stabilization`: 成功
+
+## 残存リスク
+
+- `agent-readonly` profile は CDK lookup role を assume できないため、実環境の
+  `cdk diff` は未実施です。デプロイ前に lookup 可能な承認済み profile で
+  cloud diff を確認する必要があります。
+- rolling update の pause はアプリケーションの正常性を保証しないため、初回
+  デプロイ中は ECS running task、新規 container instance、ALB health を監視します。
+- 既存の deprecated `containerInsights`、ECS IMDS、既定
+  `minHealthyPercent` の warning は今回のスコープ外です。
+- `npm ci` が報告する依存関係 vulnerability は今回のスコープ外です。

--- a/docs/superpowers/plans/2026-07-22-asg-stabilization.md
+++ b/docs/superpowers/plans/2026-07-22-asg-stabilization.md
@@ -138,7 +138,7 @@ test('SQS Queue and SNS Topic Created', () => {
 });
 ```
 
-The `Match` import is intentionally introduced here because Task 3 uses it for partial array assertions.
+The `Match` import is intentionally introduced here because Task 3 uses CDK assertion matchers.
 
 - [ ] **Step 2: Verify the fixture compiles and the existing test passes**
 

--- a/docs/superpowers/plans/2026-07-22-asg-stabilization.md
+++ b/docs/superpowers/plans/2026-07-22-asg-stabilization.md
@@ -13,7 +13,7 @@
 - Start from `feature/asg-stabilization`, which branches from `develop` at `ed525fc`.
 - Preserve `feature/full-refactor` at `155db42`; do not merge, rebase, or reset it.
 - Reuse only `67024a6` and `e9f190e` from the ASG work before adding the test repair and capacity fix.
-- Keep `desiredCount: 2`, `PlacementConstraint.distinctInstances()`, and `PlacementStrategy.packedByMemory()`.
+- Keep `desiredCount: 2`, `minHealthyPercent: 100`, `PlacementConstraint.distinctInstances()`, and `PlacementStrategy.packedByMemory()`.
 - Set ASG `maxCapacity` to exactly `4`.
 - Keep the six Graviton Spot types: `t4g.small`, `t4g.medium`, `m6g.medium`, `m7g.medium`, `c6g.medium`, and `c7g.medium`.
 - Keep Spot allocation strategy `capacity-optimized` and 100% Spot capacity.
@@ -236,6 +236,16 @@ test('ECS keeps two tasks on distinct container instances', () => {
     ])
   });
 });
+
+test('ECS keeps all desired tasks healthy during deployments', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::ECS::Service', {
+    DeploymentConfiguration: Match.objectLike({
+      MinimumHealthyPercent: 100
+    })
+  });
+});
 ```
 
 - [ ] **Step 2: Run the tests and confirm the regressions fail**
@@ -246,9 +256,9 @@ Run:
 mise exec -- npm test -- --runInBand
 ```
 
-Expected: the new capacity assertion fails while `MaxSize` is `"1"`, and the rolling migration assertion fails while `AutoScalingRollingUpdate` is absent. Confirm both failures before changing production code.
+Expected: the new capacity assertion fails while `MaxSize` is `"1"`, the rolling migration assertion fails while `AutoScalingRollingUpdate` is absent, and the ECS deployment assertion fails while `MinimumHealthyPercent` is `50`. Confirm the failures before changing production code.
 
-- [ ] **Step 3: Set the ASG maximum capacity and rolling migration policy**
+- [ ] **Step 3: Set the ASG migration policy and ECS deployment availability**
 
 In the `new AutoScalingGroup(this, "miwkeyASG", ...)` properties, add the capacity and migration settings immediately after `capacityRebalance`:
 
@@ -263,6 +273,15 @@ updatePolicy: UpdatePolicy.rollingUpdate({
   pauseTime: Duration.minutes(5)
 }),
 vpcSubnets: subnetSelection,
+```
+
+In the `ApplicationLoadBalancedEc2Service` properties, keep every desired task
+healthy during deployments:
+
+```typescript
+desiredCount: 2,
+minHealthyPercent: 100,
+memoryReservationMiB: 1100,
 ```
 
 - [ ] **Step 4: Verify tests, type checking, build output, and synthesis**

--- a/docs/superpowers/plans/2026-07-22-asg-stabilization.md
+++ b/docs/superpowers/plans/2026-07-22-asg-stabilization.md
@@ -4,9 +4,9 @@
 
 **Goal:** Produce a minimal deployable branch where two Misskey ECS tasks can run on distinct EC2 instances backed by diversified Spot capacity and an ASG with enough replacement headroom.
 
-**Architecture:** Reuse the reviewed placement and Mixed Instances Policy commits without bringing in the full refactor. Repair the existing CDK test fixture, add synthesized-template regression assertions, then raise the ASG maximum capacity from the CDK default of one to four.
+**Architecture:** Reuse the reviewed placement and Mixed Instances Policy commits without bringing in the full refactor. Repair the existing CDK test fixture, add synthesized-template regression assertions, raise the ASG maximum capacity from the CDK default of one to four, and migrate existing instances to the launch template with a one-at-a-time rolling update.
 
-**Tech Stack:** TypeScript 4.9, AWS CDK v2 (`aws-cdk-lib` 2.217.0), Jest 29 with `ts-jest`, Node.js via mise
+**Tech Stack:** TypeScript 4.9, AWS CDK v2 (`aws-cdk-lib` 2.217.x and `aws-cdk` CLI 2.1132.0), Jest 29 with `ts-jest`, Node.js via mise
 
 ## Global Constraints
 
@@ -19,7 +19,7 @@
 - Keep Spot allocation strategy `capacity-optimized` and 100% Spot capacity.
 - Run Node.js, npm, and CDK commands through `mise exec --`.
 - Do not stage or commit the existing untracked `.ai/` and `.claude/` directories.
-- Commit tracked transpiled `.js` outputs produced by the final successful build; do not add a generated-file cleanup to this branch.
+- Treat colocated generated `.js` and `.d.ts` files as ignored build artifacts. TypeScript is the source of truth; do not stage generated outputs.
 
 ---
 
@@ -162,17 +162,15 @@ git commit -m "test(stack): repair public stack fixture"
 
 Expected: one test-only commit; `.ai/` and `.claude/` remain untracked.
 
-### Task 3: Add ASG regression coverage and capacity headroom
+### Task 3: Add ASG regression coverage, capacity headroom, and rolling migration
 
 **Files:**
 - Modify: `test/miwkey-public.test.ts`
 - Modify: `lib/miwkey-public-stack.ts`
-- Modify after build: `test/miwkey-public.test.js`
-- Modify after build: `lib/miwkey-public-stack.js`
 
 **Interfaces:**
-- Consumes: `createTemplate(): Template` from Task 2 and CDK `Match.arrayWith()` / `Match.objectLike()` assertions.
-- Produces: `AWS::AutoScaling::AutoScalingGroup.MaxSize = "4"` while preserving ECS desired count, placement, and Spot pool properties.
+- Consumes: `createTemplate(): Template` from Task 2, CDK assertions, and `UpdatePolicy.rollingUpdate()`.
+- Produces: `AWS::AutoScaling::AutoScalingGroup.MaxSize = "4"` and a top-level rolling `UpdatePolicy` while preserving ECS desired count, placement, and Spot pool properties.
 
 - [ ] **Step 1: Add synthesized-template regression tests**
 
@@ -187,6 +185,20 @@ test('ASG has capacity for redundant tasks and replacement headroom', () => {
   });
 });
 
+test('ASG rolls launch template migration without dropping all instances', () => {
+  const template = createTemplate();
+
+  template.hasResource('AWS::AutoScaling::AutoScalingGroup', {
+    UpdatePolicy: {
+      AutoScalingRollingUpdate: {
+        MaxBatchSize: 1,
+        MinInstancesInService: 1,
+        PauseTime: 'PT5M'
+      }
+    }
+  });
+});
+
 test('ASG uses diversified capacity-optimized Spot pools', () => {
   const template = createTemplate();
 
@@ -198,7 +210,7 @@ test('ASG uses diversified capacity-optimized Spot pools', () => {
         SpotAllocationStrategy: 'capacity-optimized'
       }),
       LaunchTemplate: Match.objectLike({
-        Overrides: Match.arrayWith([
+        Overrides: Match.arrayEquals([
           { InstanceType: 't4g.small' },
           { InstanceType: 't4g.medium' },
           { InstanceType: 'm6g.medium' },
@@ -216,17 +228,17 @@ test('ECS keeps two tasks on distinct container instances', () => {
 
   template.hasResourceProperties('AWS::ECS::Service', {
     DesiredCount: 2,
-    PlacementConstraints: Match.arrayWith([
+    PlacementConstraints: Match.arrayEquals([
       { Type: 'distinctInstance' }
     ]),
-    PlacementStrategies: Match.arrayWith([
+    PlacementStrategies: Match.arrayEquals([
       { Field: 'MEMORY', Type: 'binpack' }
     ])
   });
 });
 ```
 
-- [ ] **Step 2: Run the tests and confirm the capacity regression fails**
+- [ ] **Step 2: Run the tests and confirm the regressions fail**
 
 Run:
 
@@ -234,16 +246,22 @@ Run:
 mise exec -- npm test -- --runInBand
 ```
 
-Expected: three tests pass and `ASG has capacity for redundant tasks and replacement headroom` fails because the synthesized `MaxSize` is `"1"`, not `"4"`.
+Expected: the new capacity assertion fails while `MaxSize` is `"1"`, and the rolling migration assertion fails while `AutoScalingRollingUpdate` is absent. Confirm both failures before changing production code.
 
-- [ ] **Step 3: Set the ASG maximum capacity**
+- [ ] **Step 3: Set the ASG maximum capacity and rolling migration policy**
 
-In the `new AutoScalingGroup(this, "miwkeyASG", ...)` properties, add `maxCapacity` immediately after `capacityRebalance`:
+In the `new AutoScalingGroup(this, "miwkeyASG", ...)` properties, add the capacity and migration settings immediately after `capacityRebalance`:
 
 ```typescript
 capacityRebalance: true,
 // Two steady-state instances plus room for rolling replacement and Spot rebalance.
 maxCapacity: 4,
+migrateToLaunchTemplate: true,
+updatePolicy: UpdatePolicy.rollingUpdate({
+  maxBatchSize: 1,
+  minInstancesInService: 1,
+  pauseTime: Duration.minutes(5)
+}),
 vpcSubnets: subnetSelection,
 ```
 
@@ -255,11 +273,11 @@ Run:
 mise exec -- npm test -- --runInBand
 mise exec -- npx tsc --noEmit
 mise exec -- npm run build
-mise exec -- npm run synth -- --quiet
+mise exec -- npm run synth -- --quiet --output <fresh /tmp path>
 git diff --check
 ```
 
-Expected: Jest reports `4 passed, 4 total`; TypeScript, build, synth, and diff checks all exit zero. The build updates the tracked JavaScript files to match their TypeScript sources.
+Expected: Jest, TypeScript, build, synth, and diff checks all exit zero. Build outputs remain ignored; the TypeScript sources contain the persistent change.
 
 - [ ] **Step 5: Review and commit the capacity fix with its regression tests**
 
@@ -267,13 +285,13 @@ Run:
 
 ```bash
 git status --short
-git diff -- lib/miwkey-public-stack.ts lib/miwkey-public-stack.js test/miwkey-public.test.ts test/miwkey-public.test.js
-git add lib/miwkey-public-stack.ts lib/miwkey-public-stack.js test/miwkey-public.test.ts test/miwkey-public.test.js
+git diff -- lib/miwkey-public-stack.ts test/miwkey-public.test.ts
+git add lib/miwkey-public-stack.ts test/miwkey-public.test.ts
 git diff --cached --check
-git commit -m "fix(ecs): allow redundant task placement"
+git commit -m "fix(asg): add safe launch template migration"
 ```
 
-Expected: the commit contains `maxCapacity: 4`, the three ASG/ECS regression tests, and synchronized tracked JavaScript. It does not contain `.ai/`, `.claude/`, dependency upgrades, Managed Instances, or WARP changes.
+Expected: the commit contains `maxCapacity: 4`, safe launch template migration, and the ASG/ECS regression tests. It does not contain generated JavaScript, `.ai/`, `.claude/`, dependency upgrades, Managed Instances, or WARP changes.
 
 ### Task 4: Validate the deployable branch and create the extension infrastructure branch
 
@@ -292,22 +310,22 @@ Run:
 mise exec -- npm ci
 mise exec -- npm test -- --runInBand
 mise exec -- npm run build
-mise exec -- npm run synth -- --quiet
+mise exec -- npm run synth -- --quiet --output <fresh /tmp path>
 git status --short --branch
 ```
 
-Expected: installation, four tests, build, and synth succeed. Status lists only the existing untracked `.ai/` and `.claude/` directories.
+Expected: installation, tests, build, and synth succeed. Status lists only the existing untracked `.ai/` and `.claude/` directories.
 
-- [ ] **Step 2: Attempt a read-only deployment diff**
+- [ ] **Step 2: Complete the mandatory pre-deployment cloud diff**
 
 Run:
 
 ```bash
-mise exec -- aws sts get-caller-identity --profile agent-readonly
-mise exec -- npx cdk diff MiwkeyPublicStack --profile agent-readonly
+mise exec -- aws sts get-caller-identity --profile "$CDK_LOOKUP_PROFILE"
+mise exec -- npx cdk diff MiwkeyPublicStack --profile "$CDK_LOOKUP_PROFILE"
 ```
 
-Expected: STS identifies the configured account. If ViewOnlyAccess permits all reads required by CDK, the diff shows the ASG, launch template, IAM role, and ECS placement changes without deploying them. A denied read is recorded as an IAM limitation and does not replace the required local synthesis and assertion checks.
+Expected: `CDK_LOOKUP_PROFILE` identifies credentials that can assume the environment's CDK lookup role, and the diff shows the ASG, launch template, IAM role, ECS placement, and rolling update changes without deploying them. A successful cloud diff is a mandatory pre-deployment gate. The current `agent-readonly` ViewOnly profile did not complete this gate and must not be cited as satisfying it.
 
 - [ ] **Step 3: Audit the final history and branch contents**
 
@@ -321,14 +339,12 @@ git diff --check develop...feature/asg-stabilization
 
 Expected: history contains the AWS design document, the two restored ASG commits, the test fixture repair, and the capacity fix. The diff contains no full-refactor-only files or changes.
 
-- [ ] **Step 4: Create the next branch without adding implementation**
+- [ ] **Step 4: Let the controller create the next branch after final re-review**
 
 Run:
 
 ```bash
-git switch -c feature/notification-extension-infra
 git rev-parse feature/asg-stabilization
-git rev-parse feature/notification-extension-infra
 ```
 
-Expected: both hashes are identical. The new branch contains no notification extension infrastructure changes yet and is ready for the separate implementation session.
+Expected: this implementation session leaves `feature/notification-extension-infra` untouched. After final re-review passes, the controller moves that branch to the verified `feature/asg-stabilization` tip without adding notification infrastructure in this fix.

--- a/docs/superpowers/plans/2026-07-22-asg-stabilization.md
+++ b/docs/superpowers/plans/2026-07-22-asg-stabilization.md
@@ -185,14 +185,14 @@ test('ASG has capacity for redundant tasks and replacement headroom', () => {
   });
 });
 
-test('ASG rolls launch template migration without dropping all instances', () => {
+test('ASG rolls launch template migration while keeping redundant instances', () => {
   const template = createTemplate();
 
   template.hasResource('AWS::AutoScaling::AutoScalingGroup', {
     UpdatePolicy: {
       AutoScalingRollingUpdate: {
         MaxBatchSize: 1,
-        MinInstancesInService: 1,
+        MinInstancesInService: 2,
         PauseTime: 'PT5M'
       }
     }
@@ -259,7 +259,7 @@ maxCapacity: 4,
 migrateToLaunchTemplate: true,
 updatePolicy: UpdatePolicy.rollingUpdate({
   maxBatchSize: 1,
-  minInstancesInService: 1,
+  minInstancesInService: 2,
   pauseTime: Duration.minutes(5)
 }),
 vpcSubnets: subnetSelection,

--- a/docs/superpowers/plans/2026-07-22-asg-stabilization.md
+++ b/docs/superpowers/plans/2026-07-22-asg-stabilization.md
@@ -220,7 +220,7 @@ test('ECS keeps two tasks on distinct container instances', () => {
       { Type: 'distinctInstance' }
     ]),
     PlacementStrategies: Match.arrayWith([
-      { Field: 'memory', Type: 'binpack' }
+      { Field: 'MEMORY', Type: 'binpack' }
     ])
   });
 });

--- a/docs/superpowers/plans/2026-07-22-asg-stabilization.md
+++ b/docs/superpowers/plans/2026-07-22-asg-stabilization.md
@@ -1,0 +1,334 @@
+# ASG Stabilization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produce a minimal deployable branch where two Misskey ECS tasks can run on distinct EC2 instances backed by diversified Spot capacity and an ASG with enough replacement headroom.
+
+**Architecture:** Reuse the reviewed placement and Mixed Instances Policy commits without bringing in the full refactor. Repair the existing CDK test fixture, add synthesized-template regression assertions, then raise the ASG maximum capacity from the CDK default of one to four.
+
+**Tech Stack:** TypeScript 4.9, AWS CDK v2 (`aws-cdk-lib` 2.217.0), Jest 29 with `ts-jest`, Node.js via mise
+
+## Global Constraints
+
+- Start from `feature/asg-stabilization`, which branches from `develop` at `ed525fc`.
+- Preserve `feature/full-refactor` at `155db42`; do not merge, rebase, or reset it.
+- Reuse only `67024a6` and `e9f190e` from the ASG work before adding the test repair and capacity fix.
+- Keep `desiredCount: 2`, `PlacementConstraint.distinctInstances()`, and `PlacementStrategy.packedByMemory()`.
+- Set ASG `maxCapacity` to exactly `4`.
+- Keep the six Graviton Spot types: `t4g.small`, `t4g.medium`, `m6g.medium`, `m7g.medium`, `c6g.medium`, and `c7g.medium`.
+- Keep Spot allocation strategy `capacity-optimized` and 100% Spot capacity.
+- Run Node.js, npm, and CDK commands through `mise exec --`.
+- Do not stage or commit the existing untracked `.ai/` and `.claude/` directories.
+- Commit tracked transpiled `.js` outputs produced by the final successful build; do not add a generated-file cleanup to this branch.
+
+---
+
+### Task 1: Restore the reviewed placement and Spot diversification commits
+
+**Files:**
+- Modify: `lib/miwkey-public-stack.ts`
+- Modify: `package-lock.json`
+
+**Interfaces:**
+- Consumes: `MiwkeyPublicStack.miwkeyMainCluster()` and the existing ECS EC2 capacity provider.
+- Produces: A distinct-instance ECS placement constraint and an ASG Mixed Instances Policy with six ARM instance types.
+
+- [ ] **Step 1: Confirm the branch base and protected refactor tip**
+
+Run:
+
+```bash
+git branch --show-current
+git merge-base feature/asg-stabilization develop
+git rev-parse develop
+git rev-parse feature/full-refactor
+```
+
+Expected:
+
+```text
+feature/asg-stabilization
+ed525fc...
+ed525fc...
+155db42...
+```
+
+- [ ] **Step 2: Restore the placement commit**
+
+Run:
+
+```bash
+git cherry-pick 67024a6c60ecb8a8dab41485e786e3434c569d36
+```
+
+Expected: a new commit named `feat: binpack戦略かつdistinct制約に変更` that imports `PlacementConstraint`, uses `distinctInstances()`, and replaces instance spreading with memory bin-packing.
+
+- [ ] **Step 3: Restore the Mixed Instances Policy commit**
+
+Run:
+
+```bash
+git cherry-pick e9f190e1fdfd7099fe6db51b2cea0c38a0862502
+```
+
+Expected: a new commit named `feat: SpotプールをMixedInstancesPolicyで多様化` that adds the launch template, SSM instance role, Spot draining user data, six launch template overrides, and `capacity-optimized` allocation.
+
+- [ ] **Step 4: Verify the restored source tree**
+
+Run:
+
+```bash
+git diff --check
+git diff --exit-code e9f190e1fdfd7099fe6db51b2cea0c38a0862502 HEAD -- lib/miwkey-public-stack.ts package-lock.json
+git status --short
+```
+
+Expected: both diff commands exit zero. Status lists only the pre-existing untracked `.ai/` and `.claude/` directories.
+
+### Task 2: Repair the CDK stack test fixture
+
+**Files:**
+- Modify: `test/miwkey-public.test.ts`
+
+**Interfaces:**
+- Consumes: `MiwkeyPublicStackProps` requiring a VPC, subnets, two security groups, and a certificate.
+- Produces: `createTemplate(): Template`, a reusable synthesized-template fixture for all stack assertions.
+
+- [ ] **Step 1: Replace the invalid two-argument stack construction**
+
+Replace `test/miwkey-public.test.ts` with:
+
+```typescript
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { SecurityGroup, Subnet, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import * as MiwkeyPublic from '../lib/miwkey-public-stack';
+
+function createTemplate(): Template {
+  const app = new cdk.App();
+  const supportStack = new cdk.Stack(app, 'TestSupportStack');
+  const vpc = new Vpc(supportStack, 'TestVpc', {
+    maxAzs: 2,
+    natGateways: 0,
+    subnetConfiguration: [{ name: 'test-public', subnetType: SubnetType.PUBLIC }]
+  });
+  const stack = new MiwkeyPublic.MiwkeyPublicStack(app, 'MyTestStack', {
+    mainVpc: vpc,
+    mainSubnets: vpc.publicSubnets.map(subnet => subnet as Subnet),
+    defaultSG: new SecurityGroup(supportStack, 'TestDefaultSG', { vpc }),
+    loadBalancerSG: new SecurityGroup(supportStack, 'TestLoadBalancerSG', { vpc }),
+    domainCertificate: Certificate.fromCertificateArn(
+      supportStack,
+      'TestCert',
+      'arn:aws:acm:ap-northeast-1:123456789012:certificate/00000000-0000-0000-0000-000000000000'
+    )
+  });
+
+  return Template.fromStack(stack);
+}
+
+test('SQS Queue and SNS Topic Created', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::SQS::Queue', {
+    VisibilityTimeout: 300
+  });
+  template.resourceCountIs('AWS::SNS::Topic', 1);
+});
+```
+
+The `Match` import is intentionally introduced here because Task 3 uses it for partial array assertions.
+
+- [ ] **Step 2: Verify the fixture compiles and the existing test passes**
+
+Run:
+
+```bash
+mise exec -- npx tsc --noEmit
+mise exec -- npm test -- --runInBand
+```
+
+Expected: TypeScript exits zero and Jest reports `1 passed, 1 total`.
+
+- [ ] **Step 3: Commit the fixture repair**
+
+Run:
+
+```bash
+git add test/miwkey-public.test.ts
+git commit -m "test(stack): repair public stack fixture"
+```
+
+Expected: one test-only commit; `.ai/` and `.claude/` remain untracked.
+
+### Task 3: Add ASG regression coverage and capacity headroom
+
+**Files:**
+- Modify: `test/miwkey-public.test.ts`
+- Modify: `lib/miwkey-public-stack.ts`
+- Modify after build: `test/miwkey-public.test.js`
+- Modify after build: `lib/miwkey-public-stack.js`
+
+**Interfaces:**
+- Consumes: `createTemplate(): Template` from Task 2 and CDK `Match.arrayWith()` / `Match.objectLike()` assertions.
+- Produces: `AWS::AutoScaling::AutoScalingGroup.MaxSize = "4"` while preserving ECS desired count, placement, and Spot pool properties.
+
+- [ ] **Step 1: Add synthesized-template regression tests**
+
+Append these tests to `test/miwkey-public.test.ts`:
+
+```typescript
+test('ASG has capacity for redundant tasks and replacement headroom', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+    MaxSize: '4'
+  });
+});
+
+test('ASG uses diversified capacity-optimized Spot pools', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+    MixedInstancesPolicy: Match.objectLike({
+      InstancesDistribution: Match.objectLike({
+        OnDemandBaseCapacity: 0,
+        OnDemandPercentageAboveBaseCapacity: 0,
+        SpotAllocationStrategy: 'capacity-optimized'
+      }),
+      LaunchTemplate: Match.objectLike({
+        Overrides: Match.arrayWith([
+          { InstanceType: 't4g.small' },
+          { InstanceType: 't4g.medium' },
+          { InstanceType: 'm6g.medium' },
+          { InstanceType: 'm7g.medium' },
+          { InstanceType: 'c6g.medium' },
+          { InstanceType: 'c7g.medium' }
+        ])
+      })
+    })
+  });
+});
+
+test('ECS keeps two tasks on distinct container instances', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::ECS::Service', {
+    DesiredCount: 2,
+    PlacementConstraints: Match.arrayWith([
+      { Type: 'distinctInstance' }
+    ]),
+    PlacementStrategies: Match.arrayWith([
+      { Field: 'memory', Type: 'binpack' }
+    ])
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm the capacity regression fails**
+
+Run:
+
+```bash
+mise exec -- npm test -- --runInBand
+```
+
+Expected: three tests pass and `ASG has capacity for redundant tasks and replacement headroom` fails because the synthesized `MaxSize` is `"1"`, not `"4"`.
+
+- [ ] **Step 3: Set the ASG maximum capacity**
+
+In the `new AutoScalingGroup(this, "miwkeyASG", ...)` properties, add `maxCapacity` immediately after `capacityRebalance`:
+
+```typescript
+capacityRebalance: true,
+// Two steady-state instances plus room for rolling replacement and Spot rebalance.
+maxCapacity: 4,
+vpcSubnets: subnetSelection,
+```
+
+- [ ] **Step 4: Verify tests, type checking, build output, and synthesis**
+
+Run:
+
+```bash
+mise exec -- npm test -- --runInBand
+mise exec -- npx tsc --noEmit
+mise exec -- npm run build
+mise exec -- npm run synth -- --quiet
+git diff --check
+```
+
+Expected: Jest reports `4 passed, 4 total`; TypeScript, build, synth, and diff checks all exit zero. The build updates the tracked JavaScript files to match their TypeScript sources.
+
+- [ ] **Step 5: Review and commit the capacity fix with its regression tests**
+
+Run:
+
+```bash
+git status --short
+git diff -- lib/miwkey-public-stack.ts lib/miwkey-public-stack.js test/miwkey-public.test.ts test/miwkey-public.test.js
+git add lib/miwkey-public-stack.ts lib/miwkey-public-stack.js test/miwkey-public.test.ts test/miwkey-public.test.js
+git diff --cached --check
+git commit -m "fix(ecs): allow redundant task placement"
+```
+
+Expected: the commit contains `maxCapacity: 4`, the three ASG/ECS regression tests, and synchronized tracked JavaScript. It does not contain `.ai/`, `.claude/`, dependency upgrades, Managed Instances, or WARP changes.
+
+### Task 4: Validate the deployable branch and create the extension infrastructure branch
+
+**Files:**
+- Verify only: synthesized `cdk.out/` output, which remains ignored.
+
+**Interfaces:**
+- Consumes: completed `feature/asg-stabilization` tip.
+- Produces: `feature/notification-extension-infra` pointing at exactly the verified ASG stabilization tip.
+
+- [ ] **Step 1: Run the complete local verification again from the committed tree**
+
+Run:
+
+```bash
+mise exec -- npm ci
+mise exec -- npm test -- --runInBand
+mise exec -- npm run build
+mise exec -- npm run synth -- --quiet
+git status --short --branch
+```
+
+Expected: installation, four tests, build, and synth succeed. Status lists only the existing untracked `.ai/` and `.claude/` directories.
+
+- [ ] **Step 2: Attempt a read-only deployment diff**
+
+Run:
+
+```bash
+mise exec -- aws sts get-caller-identity --profile agent-readonly
+mise exec -- npx cdk diff MiwkeyPublicStack --profile agent-readonly
+```
+
+Expected: STS identifies the configured account. If ViewOnlyAccess permits all reads required by CDK, the diff shows the ASG, launch template, IAM role, and ECS placement changes without deploying them. A denied read is recorded as an IAM limitation and does not replace the required local synthesis and assertion checks.
+
+- [ ] **Step 3: Audit the final history and branch contents**
+
+Run:
+
+```bash
+git log --oneline --decorate develop..feature/asg-stabilization
+git diff --stat develop...feature/asg-stabilization
+git diff --check develop...feature/asg-stabilization
+```
+
+Expected: history contains the AWS design document, the two restored ASG commits, the test fixture repair, and the capacity fix. The diff contains no full-refactor-only files or changes.
+
+- [ ] **Step 4: Create the next branch without adding implementation**
+
+Run:
+
+```bash
+git switch -c feature/notification-extension-infra
+git rev-parse feature/asg-stabilization
+git rev-parse feature/notification-extension-infra
+```
+
+Expected: both hashes are identical. The new branch contains no notification extension infrastructure changes yet and is ready for the separate implementation session.

--- a/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
+++ b/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
@@ -55,12 +55,19 @@ runtime and test changes:
 - the existing changes from `67024a6` and `e9f190e`
 - the test setup repair needed to instantiate `MiwkeyPublicStack`
 - `maxCapacity: 4`
+- migration from the existing launch configuration to the launch template with
+  `migrateToLaunchTemplate: true`
+- a rolling update policy with a maximum batch size of one, at least one
+  instance in service, and a five-minute pause
 - regression assertions for ASG `MaxSize`, ECS `DesiredCount`, the
   `distinctInstance` placement constraint, the six Spot instance types, and
   the `capacity-optimized` allocation strategy
+- a synthesized-template assertion for top-level
+  `UpdatePolicy.AutoScalingRollingUpdate`
 
-It does not contain the CDK upgrade, Managed Instances design, WARP PoC, or the
-full-refactor `.gitignore` changes.
+Repository tooling pins only the `aws-cdk` CLI to `2.1132.0`; `aws-cdk-lib`
+remains on 2.217.x. The branch does not contain a CDK library upgrade, Managed
+Instances design, WARP PoC, or the full-refactor `.gitignore` changes.
 
 Create `feature/notification-extension-infra` from the completed
 `feature/asg-stabilization` tip. Keep `feature/full-refactor` at its current
@@ -248,7 +255,8 @@ are deployment-time values.
 
 ## 9. Deployment Order
 
-1. Merge and deploy `feature/asg-stabilization` by itself.
+1. Complete a cloud diff with credentials able to assume the CDK lookup role,
+   then merge and deploy `feature/asg-stabilization` by itself.
 2. Verify that two Misskey tasks remain placed on distinct instances and that
    Spot replacement works with the diversified pools.
 3. Complete the `miwkey-extension` cross-repository contract.
@@ -283,10 +291,14 @@ are deployment-time values.
 - TypeScript build passes.
 - Jest passes.
 - Synthesized ASG has `MaxSize: 4`.
+- Synthesized ASG has top-level `UpdatePolicy.AutoScalingRollingUpdate` with
+  `MaxBatchSize: 1`, `MinInstancesInService: 1`, and `PauseTime: PT5M`.
 - Main ECS service has `DesiredCount: 2`.
 - The service uses `distinctInstance`.
 - The ASG contains all six intended Graviton instance types.
 - Spot allocation uses `capacity-optimized`.
+- A cloud diff with credentials able to assume the CDK lookup role succeeds
+  before deployment. The current ViewOnly profile has not completed this gate.
 
 ### Notification extension infrastructure branch
 

--- a/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
+++ b/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
@@ -1,0 +1,311 @@
+# miwkey-extension AWS Integration Design
+
+- Date: 2026-07-22
+- Status: Approved for implementation
+- Repositories: `miwkey-aws`, `miwkey-extension`, `miwkey-notification-importer`
+
+## 1. Goal
+
+Deploy `miwkey-extension` as an internal-only ECS service, connect the Misskey
+backend through ECS Service Connect, and provide the persistent notification
+store required before upgrading from Misskey 12.119.0.
+
+The work is split so the current ASG availability fix can be reviewed and
+deployed independently from the notification extension resources. The existing
+`feature/full-refactor` branch remains untouched until both smaller branches
+have been merged.
+
+## 2. Scope
+
+This design covers:
+
+- the minimal ASG stabilization branch in `miwkey-aws`
+- the AWS resources for the notification extension
+- the cross-repository interface required from `miwkey-extension`
+- the internal migration path for `miwkey-notification-importer`
+- deployment, rollback, logging, and verification
+
+This design does not cover:
+
+- building or publishing the Misskey fork image
+- the Misskey 2025 application image cutover
+- database migration concurrency control for the major-version upgrade
+- execution of the production notification import
+- ECS Managed Instances, WARP, or the other full-refactor changes
+- an externally accessible notification extension endpoint
+
+## 3. Branch Structure
+
+Create the following branches in `miwkey-aws`:
+
+```text
+develop
+└─ 67024a6  placement strategy
+   └─ e9f190e  MixedInstancesPolicy
+      └─ test(ecs): repair stack test setup
+         └─ fix(ecs): allow redundant task placement
+            └─ feature/asg-stabilization
+               └─ notification extension infrastructure commits
+                  └─ feature/notification-extension-infra
+```
+
+Apart from this design document, `feature/asg-stabilization` contains only these
+runtime and test changes:
+
+- the existing changes from `67024a6` and `e9f190e`
+- the test setup repair needed to instantiate `MiwkeyPublicStack`
+- `maxCapacity: 4`
+- regression assertions for ASG `MaxSize`, ECS `DesiredCount`, the
+  `distinctInstance` placement constraint, the six Spot instance types, and
+  the `capacity-optimized` allocation strategy
+
+It does not contain the CDK upgrade, Managed Instances design, WARP PoC, or the
+full-refactor `.gitignore` changes.
+
+Create `feature/notification-extension-infra` from the completed
+`feature/asg-stabilization` tip. Keep `feature/full-refactor` at its current
+commit. After both smaller branches are merged, rebase `feature/full-refactor`
+onto the updated `develop` and drop the now-duplicate max-capacity and test
+setup changes.
+
+## 4. Runtime Architecture
+
+Run the extension as an independent ECS EC2 service in the same cluster as
+Misskey. Do not run it as a Misskey sidecar and do not add an internal or public
+load balancer.
+
+```text
+Misskey container
+  -> Service Connect client proxy
+  -> http://miwkey-extension:8080
+  -> Service Connect server proxy
+  -> miwkey-extension container
+  -> DynamoDB Notifications table
+```
+
+The Misskey service joins the namespace as a client-only Service Connect
+service. The extension joins as a client-server service and publishes the
+`miwkey-extension` alias on port 8080.
+
+The extension ECS service uses:
+
+- EC2 capacity through the existing ASG capacity provider
+- bridge network mode
+- `desiredCount: 2`
+- `distinctInstances()` so both extension tasks cannot use the same container
+  instance
+- a deployment circuit breaker with rollback enabled
+- a named HTTP port mapping for container port 8080
+- the public GHCR image pinned to an immutable `sha-<commit>` tag
+
+The existing VPC security group allows traffic within the VPC, and the current
+network ACL permits the bridge-mode ephemeral port range. No public listener or
+DNS record is created for the extension.
+
+The server ECS service must be created successfully before CloudFormation
+updates the existing Misskey service with its Service Connect client
+configuration. Express this ordering as a resource dependency.
+
+## 5. AWS Resources
+
+### 5.1 Container Image Parameter
+
+Add a required CloudFormation parameter for the extension image tag. Accept
+only immutable `sha-<commit>` tags and construct this image reference:
+
+```text
+ghcr.io/mi-24v/miwkey-extension:sha-<commit>
+```
+
+Do not use `latest` in an ECS task definition. The GHCR package is public, so
+the task execution role does not need a GitHub token or repository credentials.
+
+### 5.2 DynamoDB
+
+Create the notification table in CDK with:
+
+- partition key: `notifieeId` (`String`)
+- sort key: `sortKey` (`String`)
+- global secondary index: `notificationId-index`
+- GSI partition key: `id` (`String`)
+- GSI projection: `ALL`
+- billing mode: on-demand
+- point-in-time recovery: enabled
+- removal policy: `RETAIN`
+
+Grant only read/write data access on this table to the extension task role.
+The task role must not receive `CreateTable`, `UpdateTable`, or unrelated
+DynamoDB permissions.
+
+Production must leave `DYNAMODB_AUTO_CREATE` unset. CDK is the only production
+schema owner. The existing auto-create behavior remains available for DynamoDB
+Local and integration tests, where `DYNAMODB_AUTO_CREATE=true` is appropriate.
+
+### 5.3 Shared JWT Secret
+
+Create one generated Secrets Manager secret and set its removal policy to
+`RETAIN`. Inject the value through ECS secrets as:
+
+- `AUTH_SECRET` in the extension container
+- `NOTIFICATION_EXTENSION_SECRET` in the Misskey container
+
+Set this non-secret environment variable in Misskey:
+
+```text
+NOTIFICATION_EXTENSION_URL=http://miwkey-extension:8080
+```
+
+Do not place the secret value in CloudFormation parameters, task-definition
+plain-text environment variables, source-controlled config, or logs.
+
+Do not configure automatic secret rotation. Rotation requires a coordinated
+redeployment of both ECS services. The manual rotation procedure is:
+
+1. update the Secrets Manager value
+2. force a new extension service deployment
+3. force a new Misskey service deployment
+4. verify authenticated requests through the internal endpoint
+
+### 5.4 Outputs
+
+Export enough non-secret identifiers for operation and migration:
+
+- ECS cluster name
+- extension ECS service name
+- Service Connect namespace name
+- DynamoDB table name
+- secret ARN
+
+Never output the secret value.
+
+## 6. Cross-Repository Contract
+
+The separate `miwkey-extension` implementation must provide:
+
+- Misskey support for `NOTIFICATION_EXTENSION_URL`
+- Misskey support for `NOTIFICATION_EXTENSION_SECRET`
+- a public multi-architecture extension image at
+  `ghcr.io/mi-24v/miwkey-extension:sha-<commit>`
+- an unauthenticated `GET /healthz` endpoint
+- a distroless-compatible container health check
+- the logging contract described below
+
+Environment variables take precedence over YAML values. YAML remains a
+fallback for local development. The integration is enabled only when both URL
+and secret are present.
+
+Building and publishing the Misskey fork image belongs to the fork repository,
+not the `miwkey-extension` CI workflow. The fork image cutover and its database
+migration orchestration are separate work.
+
+## 7. Logging
+
+Keep two log groups with six-month retention:
+
+```text
+/ecs/miwkey-extension/app
+/ecs/miwkey-extension/service-connect
+```
+
+The application log group contains:
+
+- Echo request metadata
+- startup and graceful shutdown events
+- panic/recover output
+- DynamoDB and AWS configuration errors without payload data
+
+The Service Connect log group contains proxy startup and connectivity errors.
+Service Connect request access logs are disabled initially because Echo already
+logs request metadata and duplicate access logs add cost and can expose query
+parameters such as user IDs.
+
+Neither log group may contain notification payloads, JWTs, Authorization
+headers, or the shared secret.
+
+## 8. Importer Access
+
+Service Connect does not support standalone ECS tasks, and the extension has no
+load balancer. Run the one-time importer from the operator machine through an
+SSM port-forwarding session:
+
+1. find one running extension task
+2. read its bridge-mode dynamic `hostPort` from the ECS task network binding
+3. resolve the backing ECS container instance and EC2 instance ID
+4. open an SSM port forward from a local port to
+   `127.0.0.1:<hostPort>` on that instance
+5. run the importer against the local forwarded URL
+6. authenticate with a short-lived JWT generated from the shared secret
+7. close the session after import and verification
+
+The existing ECS container-instance role already includes
+`AmazonSSMManagedInstanceCore`. The production operator needs explicit
+permission to start the SSM session and read the shared secret. The extension's
+JWT middleware remains active on the forwarded connection.
+
+Document the exact AWS CLI commands after the first deployed task exists,
+because the task ARN, container instance, EC2 instance, and dynamic host port
+are deployment-time values.
+
+## 9. Deployment Order
+
+1. Merge and deploy `feature/asg-stabilization` by itself.
+2. Verify that two Misskey tasks remain placed on distinct instances and that
+   Spot replacement works with the diversified pools.
+3. Complete the `miwkey-extension` cross-repository contract.
+4. Merge `feature/notification-extension-infra`.
+5. Deploy with a known public multi-architecture `sha-<commit>` image tag.
+6. Verify two healthy extension tasks and authenticated access through an SSM
+   tunnel.
+7. In a separate change, deploy the Misskey 2025 image that consumes the URL
+   and secret environment variables.
+8. Perform the rehearsed notification import and verify migrated IDs.
+9. Rebase and continue `feature/full-refactor` only after the two smaller
+   branches are merged and stable.
+
+## 10. Failure and Rollback
+
+- The extension deployment circuit breaker rolls back failed task revisions.
+- A failed new server service prevents the dependent Misskey Service Connect
+  update from starting.
+- Rolling back the AWS code does not delete the retained table or secret.
+- Rolling back the application uses the previous Misskey task definition while
+  preserving imported DynamoDB data.
+- If the extension is temporarily unavailable, the current Misskey fork treats
+  requests as failed and falls back according to its existing notification
+  behavior. Do not treat this as a durable retry guarantee.
+- Do not combine the ASG deployment, extension infrastructure deployment, and
+  Misskey major-version cutover into one CloudFormation update.
+
+## 11. Verification
+
+### ASG branch
+
+- TypeScript build passes.
+- Jest passes.
+- Synthesized ASG has `MaxSize: 4`.
+- Main ECS service has `DesiredCount: 2`.
+- The service uses `distinctInstance`.
+- The ASG contains all six intended Graviton instance types.
+- Spot allocation uses `capacity-optimized`.
+
+### Notification extension infrastructure branch
+
+- TypeScript build and Jest pass.
+- CDK synthesis passes in the available environment.
+- The table schema, GSI, PITR, and retain policy match this design.
+- The secret is injected through ECS secrets, not plain-text environment data.
+- The extension task role can access only the notification table.
+- The extension service advertises `miwkey-extension:8080` through Service
+  Connect.
+- The Misskey service is a client and depends on the server service creation.
+- The extension service runs two tasks on distinct instances.
+- No extension ALB, public listener, or public DNS record exists.
+- Application and Service Connect logs use separate six-month log groups.
+- Service Connect request access logging is disabled.
+
+## 12. References
+
+- [Amazon ECS Service Connect](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html)
+- [Service Connect configuration overview](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect-concepts.html)
+- [Service Connect components and bridge networking](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect-concepts-deploy.html)
+- [Connecting ECS services inside a VPC](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/networking-connecting-services.html)

--- a/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
+++ b/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
@@ -293,7 +293,7 @@ are deployment-time values.
 - Synthesized ASG has `MaxSize: 4`.
 - Synthesized ASG has top-level `UpdatePolicy.AutoScalingRollingUpdate` with
   `MaxBatchSize: 1`, `MinInstancesInService: 2`, and `PauseTime: PT5M`.
-- Main ECS service has `DesiredCount: 2`.
+- Main ECS service has `DesiredCount: 2` and `MinimumHealthyPercent: 100`.
 - The service uses `distinctInstance`.
 - The ASG contains all six intended Graviton instance types.
 - Spot allocation uses `capacity-optimized`.

--- a/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
+++ b/docs/superpowers/specs/2026-07-22-notification-extension-aws-integration-design.md
@@ -292,7 +292,7 @@ are deployment-time values.
 - Jest passes.
 - Synthesized ASG has `MaxSize: 4`.
 - Synthesized ASG has top-level `UpdatePolicy.AutoScalingRollingUpdate` with
-  `MaxBatchSize: 1`, `MinInstancesInService: 1`, and `PauseTime: PT5M`.
+  `MaxBatchSize: 1`, `MinInstancesInService: 2`, and `PauseTime: PT5M`.
 - Main ECS service has `DesiredCount: 2`.
 - The service uses `distinctInstance`.
 - The ASG contains all six intended Graviton instance types.

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'mjs', 'cjs', 'jsx', 'json', 'node'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
   }

--- a/lib/miwkey-public-stack.ts
+++ b/lib/miwkey-public-stack.ts
@@ -159,7 +159,7 @@ export class MiwkeyPublicStack extends Stack {
                 migrateToLaunchTemplate: true,
                 updatePolicy: UpdatePolicy.rollingUpdate({
                     maxBatchSize: 1,
-                    minInstancesInService: 1,
+                    minInstancesInService: 2,
                     pauseTime: Duration.minutes(5)
                 }),
                 vpcSubnets: subnetSelection,

--- a/lib/miwkey-public-stack.ts
+++ b/lib/miwkey-public-stack.ts
@@ -154,6 +154,8 @@ export class MiwkeyPublicStack extends Stack {
         const miwkeyMainAsgCapacityProvider = new AsgCapacityProvider(this, "miwkeyAsgCapacityProvider", {
             autoScalingGroup: new AutoScalingGroup(this, "miwkeyASG", {
                 capacityRebalance: true,
+                // Two steady-state instances plus room for rolling replacement and Spot rebalance.
+                maxCapacity: 4,
                 vpcSubnets: subnetSelection,
                 vpc: props.mainVpc,
                 // 単一インスタンスタイプ(t4g.small)の100% Spotだと、そのAZ/タイプのプールが

--- a/lib/miwkey-public-stack.ts
+++ b/lib/miwkey-public-stack.ts
@@ -210,6 +210,7 @@ export class MiwkeyPublicStack extends Stack {
             },
             cpu: 1024,
             desiredCount: 2,
+            minHealthyPercent: 100,
             memoryReservationMiB: 1100,
             enableECSManagedTags: true,
             enableExecuteCommand: false,

--- a/lib/miwkey-public-stack.ts
+++ b/lib/miwkey-public-stack.ts
@@ -14,7 +14,7 @@ import {
     PostgresEngineVersion,
     StorageType
 } from "aws-cdk-lib/aws-rds";
-import {InstanceClass, InstanceSize, InstanceType, SubnetSelection} from "aws-cdk-lib/aws-ec2";
+import {InstanceClass, InstanceSize, InstanceType, LaunchTemplate, SubnetSelection, UserData} from "aws-cdk-lib/aws-ec2";
 import {ApplicationLoadBalancedEc2Service} from "aws-cdk-lib/aws-ecs-patterns";
 import {
     AmiHardwareType,
@@ -27,8 +27,9 @@ import {
 } from "aws-cdk-lib/aws-ecs";
 import {ApplicationLoadBalancer, IpAddressType} from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import {miwkeyConfigMountPoint, miwkeyMainTaskDefinition, miwkeyMigrationTaskDefinition} from "./taskdef";
-import {AutoScalingGroup} from "aws-cdk-lib/aws-autoscaling";
+import {AutoScalingGroup, SpotAllocationStrategy} from "aws-cdk-lib/aws-autoscaling";
 import {meilisearchDNSRecord} from "./meilisearch/meilisearch-miwkey";
+import {ManagedPolicy, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
 
 export class MiwkeyPublicStack extends Stack {
     constructor(scope: Construct, id: string, props: MiwkeyPublicStackProps) {
@@ -130,16 +131,52 @@ export class MiwkeyPublicStack extends Stack {
             containerInsights: true,
             vpc: props.mainVpc
         });
+        // mixedInstancesPolicyを使う場合、machineImage/instanceType/securityGroup/role等の
+        // launch configuration系プロパティはAutoScalingGroupに直接渡せないため、
+        // 明示的なLaunchTemplateを用意する必要がある
+        const miwkeyAsgInstanceRole = new Role(this, "miwkeyAsgInstanceRole", {
+            assumedBy: new ServicePrincipal("ec2.amazonaws.com")
+        });
+        // AutoScalingGroupPropsのssmSessionPermissionsに相当する権限を明示的に付与する
+        miwkeyAsgInstanceRole.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName("AmazonSSMManagedInstanceCore"));
+        // userDataを明示的に持たせないと、addAsgCapacityProviderがECS_CLUSTERを
+        // 注入しようとした際に「launch template does not expose its user data」でsynthが失敗する
+        const miwkeyAsgUserData = UserData.forLinux();
+        // spotInstanceDraining: trueによるECS_ENABLE_SPOT_INSTANCE_DRAINING注入は
+        // ASGのspotPriceプロパティ設定時のみ動作し、mixedInstancesPolicyでは効かないため明示する
+        miwkeyAsgUserData.addCommands("echo ECS_ENABLE_SPOT_INSTANCE_DRAINING=true >> /etc/ecs/ecs.config");
+        const miwkeyAsgLaunchTemplate = new LaunchTemplate(this, "miwkeyAsgLaunchTemplate", {
+            machineImage: EcsOptimizedImage.amazonLinux2(AmiHardwareType.ARM),
+            securityGroup: props.defaultSG,
+            role: miwkeyAsgInstanceRole,
+            userData: miwkeyAsgUserData
+        });
         const miwkeyMainAsgCapacityProvider = new AsgCapacityProvider(this, "miwkeyAsgCapacityProvider", {
             autoScalingGroup: new AutoScalingGroup(this, "miwkeyASG", {
-                instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
                 capacityRebalance: true,
-                machineImage: EcsOptimizedImage.amazonLinux2(AmiHardwareType.ARM),
-                securityGroup: props.defaultSG,
-                spotPrice: "0.015", // 10.8usd/mo
-                ssmSessionPermissions: true,
                 vpcSubnets: subnetSelection,
-                vpc: props.mainVpc
+                vpc: props.mainVpc,
+                // 単一インスタンスタイプ(t4g.small)の100% Spotだと、そのAZ/タイプのプールが
+                // 枯渇した際に何時間も代替インスタンスを起動できなくなることが確認されたため、
+                // Graviton系の複数インスタンスタイプへSpotプールを分散させる
+                mixedInstancesPolicy: {
+                    launchTemplate: miwkeyAsgLaunchTemplate,
+                    launchTemplateOverrides: [
+                        {instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL)},
+                        {instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM)},
+                        {instanceType: InstanceType.of(InstanceClass.M6G, InstanceSize.MEDIUM)},
+                        {instanceType: InstanceType.of(InstanceClass.M7G, InstanceSize.MEDIUM)},
+                        {instanceType: InstanceType.of(InstanceClass.C6G, InstanceSize.MEDIUM)},
+                        {instanceType: InstanceType.of(InstanceClass.C7G, InstanceSize.MEDIUM)}
+                    ],
+                    instancesDistribution: {
+                        onDemandBaseCapacity: 0,
+                        onDemandPercentageAboveBaseCapacity: 0, // 100% Spot
+                        // 価格最安の単一プールに寄せるlowest-priceではなく、
+                        // 空き容量に応じてプールを選ぶcapacity-optimizedで在庫枯渇を回避する
+                        spotAllocationStrategy: SpotAllocationStrategy.CAPACITY_OPTIMIZED
+                    }
+                }
             }),
             enableManagedDraining: true,
             enableManagedScaling: true,

--- a/lib/miwkey-public-stack.ts
+++ b/lib/miwkey-public-stack.ts
@@ -27,7 +27,7 @@ import {
 } from "aws-cdk-lib/aws-ecs";
 import {ApplicationLoadBalancer, IpAddressType} from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import {miwkeyConfigMountPoint, miwkeyMainTaskDefinition, miwkeyMigrationTaskDefinition} from "./taskdef";
-import {AutoScalingGroup, SpotAllocationStrategy} from "aws-cdk-lib/aws-autoscaling";
+import {AutoScalingGroup, SpotAllocationStrategy, UpdatePolicy} from "aws-cdk-lib/aws-autoscaling";
 import {meilisearchDNSRecord} from "./meilisearch/meilisearch-miwkey";
 import {ManagedPolicy, Role, ServicePrincipal} from "aws-cdk-lib/aws-iam";
 
@@ -156,6 +156,12 @@ export class MiwkeyPublicStack extends Stack {
                 capacityRebalance: true,
                 // Two steady-state instances plus room for rolling replacement and Spot rebalance.
                 maxCapacity: 4,
+                migrateToLaunchTemplate: true,
+                updatePolicy: UpdatePolicy.rollingUpdate({
+                    maxBatchSize: 1,
+                    minInstancesInService: 1,
+                    pauseTime: Duration.minutes(5)
+                }),
                 vpcSubnets: subnetSelection,
                 vpc: props.mainVpc,
                 // 単一インスタンスタイプ(t4g.small)の100% Spotだと、そのAZ/タイプのプールが

--- a/lib/miwkey-public-stack.ts
+++ b/lib/miwkey-public-stack.ts
@@ -22,6 +22,7 @@ import {
     Cluster,
     ContainerDependencyCondition,
     EcsOptimizedImage,
+    PlacementConstraint,
     PlacementStrategy
 } from "aws-cdk-lib/aws-ecs";
 import {ApplicationLoadBalancer, IpAddressType} from "aws-cdk-lib/aws-elasticloadbalancingv2";
@@ -175,8 +176,11 @@ export class MiwkeyPublicStack extends Stack {
                 securityGroup: props.loadBalancerSG
             }),
             openListener: false,
+            placementConstraints: [
+                PlacementConstraint.distinctInstances()
+            ],
             placementStrategies: [
-                PlacementStrategy.spreadAcrossInstances()
+                PlacementStrategy.packedByMemory()
             ],
             redirectHTTP: true,
             taskImageOptions: miwkeyMainTaskDefinition()

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             "devDependencies": {
                 "@types/jest": "^29.2.4",
                 "@types/node": "18.11.15",
-                "aws-cdk": "^2.131.0",
+                "aws-cdk": "2.1132.0",
                 "jest": "^29.3.1",
                 "ts-jest": "^29.0.3",
                 "ts-node": "^10.9.1",
@@ -1284,18 +1284,16 @@
             }
         },
         "node_modules/aws-cdk": {
-            "version": "2.131.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.131.0.tgz",
-            "integrity": "sha512-ji+MwGFGC88HE/EqV6/VARBp5mu3nXIDa/GYwtGycJqu6WqXhNZXWeDH0JsWaY6+BSUdpY6pr6KWpV+MDyVkDg==",
+            "version": "2.1132.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1132.0.tgz",
+            "integrity": "sha512-kcIzBZQO+2v+F97iaeI29fdOUQEx44wr0qDb9HXNqdU82V+1ZKI1KuFlHwH2nq7+6iNc1bu60se4hFf+2d7vXg==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "cdk": "bin/cdk"
             },
             "engines": {
-                "node": ">= 14.15.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
+                "node": ">= 18.0.0"
             }
         },
         "node_modules/aws-cdk-lib": {
@@ -5133,13 +5131,10 @@
             }
         },
         "aws-cdk": {
-            "version": "2.131.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.131.0.tgz",
-            "integrity": "sha512-ji+MwGFGC88HE/EqV6/VARBp5mu3nXIDa/GYwtGycJqu6WqXhNZXWeDH0JsWaY6+BSUdpY6pr6KWpV+MDyVkDg==",
-            "dev": true,
-            "requires": {
-                "fsevents": "2.3.2"
-            }
+            "version": "2.1132.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1132.0.tgz",
+            "integrity": "sha512-kcIzBZQO+2v+F97iaeI29fdOUQEx44wr0qDb9HXNqdU82V+1ZKI1KuFlHwH2nq7+6iNc1bu60se4hFf+2d7vXg==",
+            "dev": true
         },
         "aws-cdk-lib": {
             "version": "2.217.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3580,6 +3580,7 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
@@ -6794,7 +6795,8 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
         },
         "shebang-command": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "devDependencies": {
         "@types/jest": "^29.2.4",
         "@types/node": "18.11.15",
+        "aws-cdk": "2.1132.0",
         "jest": "^29.3.1",
         "ts-jest": "^29.0.3",
-        "aws-cdk": "^2.131.0",
         "ts-node": "^10.9.1",
         "typescript": "~4.9.4"
     },

--- a/test/miwkey-public.test.ts
+++ b/test/miwkey-public.test.ts
@@ -48,14 +48,14 @@ test('ASG has capacity for redundant tasks and replacement headroom', () => {
   });
 });
 
-test('ASG rolls launch template migration without dropping all instances', () => {
+test('ASG rolls launch template migration while keeping redundant instances', () => {
   const template = createTemplate();
 
   template.hasResource('AWS::AutoScaling::AutoScalingGroup', {
     UpdatePolicy: {
       AutoScalingRollingUpdate: {
         MaxBatchSize: 1,
-        MinInstancesInService: 1,
+        MinInstancesInService: 2,
         PauseTime: 'PT5M'
       }
     }

--- a/test/miwkey-public.test.ts
+++ b/test/miwkey-public.test.ts
@@ -99,3 +99,13 @@ test('ECS keeps two tasks on distinct container instances', () => {
     ])
   });
 });
+
+test('ECS keeps all desired tasks healthy during deployments', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::ECS::Service', {
+    DeploymentConfiguration: Match.objectLike({
+      MinimumHealthyPercent: 100
+    })
+  });
+});

--- a/test/miwkey-public.test.ts
+++ b/test/miwkey-public.test.ts
@@ -36,6 +36,10 @@ test('SQS Queue and SNS Topic Created', () => {
   template.resourceCountIs('AWS::SNS::Topic', 1);
 });
 
+test('Jest resolves colocated stack imports to TypeScript sources', () => {
+  expect(require.resolve('../lib/miwkey-public-stack')).toMatch(/\.ts$/);
+});
+
 test('ASG has capacity for redundant tasks and replacement headroom', () => {
   const template = createTemplate();
 
@@ -55,7 +59,7 @@ test('ASG uses diversified capacity-optimized Spot pools', () => {
         SpotAllocationStrategy: 'capacity-optimized'
       }),
       LaunchTemplate: Match.objectLike({
-        Overrides: Match.arrayWith([
+        Overrides: Match.arrayEquals([
           { InstanceType: 't4g.small' },
           { InstanceType: 't4g.medium' },
           { InstanceType: 'm6g.medium' },

--- a/test/miwkey-public.test.ts
+++ b/test/miwkey-public.test.ts
@@ -1,14 +1,34 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { SecurityGroup, Subnet, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import * as MiwkeyPublic from '../lib/miwkey-public-stack';
 
-test('SQS Queue and SNS Topic Created', () => {
+function createTemplate(): Template {
   const app = new cdk.App();
-  // WHEN
-  const stack = new MiwkeyPublic.MiwkeyPublicStack(app, 'MyTestStack');
-  // THEN
+  const supportStack = new cdk.Stack(app, 'TestSupportStack');
+  const vpc = new Vpc(supportStack, 'TestVpc', {
+    maxAzs: 2,
+    natGateways: 0,
+    subnetConfiguration: [{ name: 'test-public', subnetType: SubnetType.PUBLIC }]
+  });
+  const stack = new MiwkeyPublic.MiwkeyPublicStack(app, 'MyTestStack', {
+    mainVpc: vpc,
+    mainSubnets: vpc.publicSubnets.map(subnet => subnet as Subnet),
+    defaultSG: new SecurityGroup(supportStack, 'TestDefaultSG', { vpc }),
+    loadBalancerSG: new SecurityGroup(supportStack, 'TestLoadBalancerSG', { vpc }),
+    domainCertificate: Certificate.fromCertificateArn(
+      supportStack,
+      'TestCert',
+      'arn:aws:acm:ap-northeast-1:123456789012:certificate/00000000-0000-0000-0000-000000000000'
+    )
+  });
 
-  const template = Template.fromStack(stack);
+  return Template.fromStack(stack);
+}
+
+test('SQS Queue and SNS Topic Created', () => {
+  const template = createTemplate();
 
   template.hasResourceProperties('AWS::SQS::Queue', {
     VisibilityTimeout: 300

--- a/test/miwkey-public.test.ts
+++ b/test/miwkey-public.test.ts
@@ -35,3 +35,49 @@ test('SQS Queue and SNS Topic Created', () => {
   });
   template.resourceCountIs('AWS::SNS::Topic', 1);
 });
+
+test('ASG has capacity for redundant tasks and replacement headroom', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+    MaxSize: '4'
+  });
+});
+
+test('ASG uses diversified capacity-optimized Spot pools', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::AutoScaling::AutoScalingGroup', {
+    MixedInstancesPolicy: Match.objectLike({
+      InstancesDistribution: Match.objectLike({
+        OnDemandBaseCapacity: 0,
+        OnDemandPercentageAboveBaseCapacity: 0,
+        SpotAllocationStrategy: 'capacity-optimized'
+      }),
+      LaunchTemplate: Match.objectLike({
+        Overrides: Match.arrayWith([
+          { InstanceType: 't4g.small' },
+          { InstanceType: 't4g.medium' },
+          { InstanceType: 'm6g.medium' },
+          { InstanceType: 'm7g.medium' },
+          { InstanceType: 'c6g.medium' },
+          { InstanceType: 'c7g.medium' }
+        ])
+      })
+    })
+  });
+});
+
+test('ECS keeps two tasks on distinct container instances', () => {
+  const template = createTemplate();
+
+  template.hasResourceProperties('AWS::ECS::Service', {
+    DesiredCount: 2,
+    PlacementConstraints: Match.arrayWith([
+      { Type: 'distinctInstance' }
+    ]),
+    PlacementStrategies: Match.arrayWith([
+      { Field: 'MEMORY', Type: 'binpack' }
+    ])
+  });
+});

--- a/test/miwkey-public.test.ts
+++ b/test/miwkey-public.test.ts
@@ -48,6 +48,20 @@ test('ASG has capacity for redundant tasks and replacement headroom', () => {
   });
 });
 
+test('ASG rolls launch template migration without dropping all instances', () => {
+  const template = createTemplate();
+
+  template.hasResource('AWS::AutoScaling::AutoScalingGroup', {
+    UpdatePolicy: {
+      AutoScalingRollingUpdate: {
+        MaxBatchSize: 1,
+        MinInstancesInService: 1,
+        PauseTime: 'PT5M'
+      }
+    }
+  });
+});
+
 test('ASG uses diversified capacity-optimized Spot pools', () => {
   const template = createTemplate();
 
@@ -77,10 +91,10 @@ test('ECS keeps two tasks on distinct container instances', () => {
 
   template.hasResourceProperties('AWS::ECS::Service', {
     DesiredCount: 2,
-    PlacementConstraints: Match.arrayWith([
+    PlacementConstraints: Match.arrayEquals([
       { Type: 'distinctInstance' }
     ]),
-    PlacementStrategies: Match.arrayWith([
+    PlacementStrategies: Match.arrayEquals([
       { Field: 'MEMORY', Type: 'binpack' }
     ])
   });


### PR DESCRIPTION
## 概要

#8 対策 + rolling updateの冗長性確保

## 変更内容

- ECSに`distinctInstance`とメモリ基準のbinpackを設定
- ECSの`minHealthyPercent`を100%に設定
- ASGの`maxCapacity`を4に拡張
- 6種類のGravitonインスタンスを使用するMixedInstancesPolicyを導入
- Spot allocation strategyに`capacity-optimized`を設定
- Launch ConfigurationからLaunch Templateへ移行
- rolling updateで`MinInstancesInService: 2`、`MaxBatchSize: 1`を設定
- CDK CLIを`2.1132.0`に固定
- ASG、Spot override、ECS placement、deployment設定の回帰テストを追加
- notification extensionの後続実装向け設計書を追加

## 実環境確認

- 実ASGは`DesiredCapacity: 2`でHealthyな2台が稼働
- 実ECS serviceは`desiredCount: 2`、`runningCount: 2`
- パラメータ指定済みChange SetではRDS Secret差分なし
- ARM64 ECS Optimized AL2 AMIは`20251031`版から`20260714`版へ更新
- 新AMIはavailable

## 検証

- `mise exec -- npm test -- --runInBand`（7 tests passed）
- `mise exec -- npx tsc --noEmit`
- `mise exec -- npm run build`
- `mise exec -- npm run synth -- MiwkeyPublicStack --quiet --output <fresh-dir>`
- `git diff --check develop...feature/asg-stabilization`

synth結果:

- ASG `MaxSize: 4`
- `MinInstancesInService: 2`
- `MaxBatchSize: 1`
- `PauseTime: PT5M`
- Spot allocation strategy `capacity-optimized`
- ECS `DesiredCount: 2`
- ECS `MinimumHealthyPercent: 100`
- ECS `MaximumPercent: 200`
- ECS placement `distinctInstance`
- ECS placement `binpack: MEMORY`

## デプロイ前の確認

Change Setで以下を確認

- RDS Secret差分がない
- ASGが最低2台を維持する
- ECSが最低100%のhealthy taskを維持する
- ASGおよびCapacity Providerが想定外に置換されない

初回デプロイ中はECS running task、新規container instance、
ASG activity、ALB target healthを監視。

## 対象外

- `price-capacity-optimized`への変更
-  AL2023対応
- deprecated `containerInsights`対応
- ECS ホストIMDSアクセス遮断方式の移行